### PR TITLE
Add configurable timeout value

### DIFF
--- a/test/lib/prerender_rails.rb
+++ b/test/lib/prerender_rails.rb
@@ -102,6 +102,18 @@ describe Rack::Prerender do
   end
 
 
+  it 'should return a timeout error to the crawler if the request takes longer than the read_timeout argument' do
+    request = Rack::MockRequest.env_for '/', 'HTTP_USER_AGENT' => bot
+    stub_request(:get, @prerender.build_api_url(request))
+      .with(headers: { 'User-Agent': bot })
+      .to_return(body: '503 Service Unavailable', status: 503)
+    response = Rack::Prerender.new(@app, read_timeout: 22).call(request)
+
+    assert_equal response[0], 503
+    assert_equal response[2], ['503 Service Unavailable']
+  end
+
+
   it "should continue to app routes if the url is part of the regex specific blacklist" do
     request = Rack::MockRequest.env_for "/search/things/123/page", "HTTP_USER_AGENT" => bot
     response = Rack::Prerender.new(@app, blacklist: ['^/search', '/help']).call(request)


### PR DESCRIPTION
**Description**

This PR adds a new configurable argument `read_timeout` to the options hash to prevent bot requests from taking too long and constantly occupying server threads, which could cause a slow response alert on our end.

JIRA issue: https://himama.atlassian.net/browse/FLRS-790